### PR TITLE
feat: integrate chatbot service into platform deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ config:
 	@cp config/env.backend.template config/.env.backend
 	@cp config/env.frontend.template config/.env.frontend
 	@cp config/env.docker.template config/.env.docker
+	@cp config/env.chatbot.template config/.env.chatbot
 	@echo "📋 Template files copied successfully!"
 	@echo ""
 	@# Frontend configuration
@@ -95,6 +96,9 @@ config:
 	@read -p "API Base URL [http://localhost:8000]: " api_url; \
 	api_url=$${api_url:-http://localhost:8000}; \
 	sed -i'' -e "s|^NEXT_PUBLIC_API_BASE_URL=.*|NEXT_PUBLIC_API_BASE_URL=$$api_url|" config/.env.frontend
+	@read -p "Chatbot URL [http://localhost:8001]: " chatbot_url; \
+	chatbot_url=$${chatbot_url:-http://localhost:8001}; \
+	sed -i'' -e "s|^NEXT_PUBLIC_CHATBOT_URL=.*|NEXT_PUBLIC_CHATBOT_URL=$$chatbot_url|" config/.env.frontend
 	@echo ""
 	@# Backend configuration
 	@echo "=== Backend Configuration ==="
@@ -105,11 +109,21 @@ config:
 	admin_password=$${admin_password:-admin}; \
 	sed -i'' -e "s|^DEFAULT_ADMIN_PASSWORD=.*|DEFAULT_ADMIN_PASSWORD=$$admin_password|" config/.env.backend
 	@echo ""
+	@# Chatbot configuration
+	@echo "=== Chatbot Configuration ==="
+	@read -p "Tokamak AI API Key [your-api-key-here]: " ai_api_key; \
+	ai_api_key=$${ai_api_key:-your-api-key-here}; \
+	sed -i'' -e "s|^TOKAMAK_AI_API_KEY=.*|TOKAMAK_AI_API_KEY=$$ai_api_key|" config/.env.chatbot
+	@read -p "Chatbot CORS Origins [http://localhost:3000]: " cors_origins; \
+	cors_origins=$${cors_origins:-http://localhost:3000}; \
+	sed -i'' -e "s|^CORS_ORIGINS=.*|CORS_ORIGINS=$$cors_origins|" config/.env.chatbot
+	@echo ""
 	@echo "✅ Environment variables configured successfully!"
 	@echo "📁 Configuration files created:"
 	@echo "   - config/.env.docker"
 	@echo "   - config/.env.frontend"
 	@echo "   - config/.env.backend"
+	@echo "   - config/.env.chatbot"
 
 # ========================================
 # EC2 Infrastructure Commands
@@ -229,6 +243,10 @@ ec2-deploy:
 		admin_password="admin"; \
 	fi; \
 	echo ""; \
+	echo "=== Chatbot Configuration ==="; \
+	read -p "Tokamak AI API Key (for chatbot, leave empty to skip): " ai_api_key; \
+	ai_api_key=$${ai_api_key:-}; \
+	echo ""; \
 	. ec2/.env; \
 	if [ -z "$$KEY_PAIR_NAME" ]; then \
 		echo "❌ KEY_PAIR_NAME not found in ec2/.env file."; \
@@ -242,6 +260,7 @@ ec2-deploy:
 	export TF_VAR_private_key_path="$$HOME/.ssh/$$KEY_PAIR_NAME"; \
 	export TF_VAR_admin_email="$$admin_email"; \
 	export TF_VAR_admin_password="$$admin_password"; \
+	export TF_VAR_tokamak_ai_api_key="$$ai_api_key"; \
 	echo "📝 Writing environment variables to .env file..."; \
 	echo "KEY_PAIR_NAME=$$KEY_PAIR_NAME" > ec2/.env; \
 	echo "TF_VAR_instance_type=$$instance_type" >> ec2/.env; \
@@ -251,6 +270,7 @@ ec2-deploy:
 	echo "TF_VAR_private_key_path=$$HOME/.ssh/$$KEY_PAIR_NAME" >> ec2/.env; \
 	echo "TF_VAR_admin_email=$$admin_email" >> ec2/.env; \
 	echo "TF_VAR_admin_password=$$admin_password" >> ec2/.env; \
+	echo "TF_VAR_tokamak_ai_api_key=$$ai_api_key" >> ec2/.env; \
 	echo "🔑 Using SSH key pair: $$KEY_PAIR_NAME"; \
 	echo "🔑 Using public key path: $$HOME/.ssh/$$KEY_PAIR_NAME.pub"; \
 	echo "🔑 Using private key path: $$HOME/.ssh/$$KEY_PAIR_NAME"; \

--- a/config/env.chatbot.template
+++ b/config/env.chatbot.template
@@ -6,7 +6,9 @@ TOKAMAK_AI_BASE_URL=https://api.ai.tokamak.network
 TOKAMAK_AI_API_KEY=your-api-key-here
 
 # Chat Model
-CHAT_MODEL=claude-sonnet-4.5
+# Default: Qwen3 80B Next (served via Tokamak AI Gateway)
+# Other options depend on gateway configuration (e.g. qwen3-235b, claude-sonnet-4.5)
+CHAT_MODEL=qwen3-80b-next
 
 # Embedding Provider (local = free, no external API needed)
 EMBEDDING_PROVIDER=local

--- a/config/env.chatbot.template
+++ b/config/env.chatbot.template
@@ -1,0 +1,30 @@
+# Chatbot Environment Configuration
+# Copy this file to config/.env.chatbot and fill in your values
+
+# Tokamak AI Gateway (Required)
+TOKAMAK_AI_BASE_URL=https://api.ai.tokamak.network
+TOKAMAK_AI_API_KEY=your-api-key-here
+
+# Chat Model
+CHAT_MODEL=claude-sonnet-4.5
+
+# Embedding Provider (local = free, no external API needed)
+EMBEDDING_PROVIDER=local
+LOCAL_EMBEDDING_MODEL=all-MiniLM-L6-v2
+
+# Vector Database
+CHROMA_PERSIST_DIR=/app/data/chroma_db
+CHROMA_COLLECTION_NAME=tokamak_docs
+
+# Server Config
+HOST=0.0.0.0
+PORT=8001
+LOG_LEVEL=INFO
+
+# CORS Origins (update with your production frontend URL)
+CORS_ORIGINS=http://localhost:3000
+
+# RAG Config
+RAG_TOP_K=4
+CHUNK_SIZE=1000
+CHUNK_OVERLAP=200

--- a/config/env.docker.template
+++ b/config/env.docker.template
@@ -7,3 +7,6 @@ TRH_BACKEND_VERSION=v1.0.1-alpha
 
 # UI service version
 TRH_PLATFORM_UI_VERSION=1.0.0
+
+# Chatbot service version
+TRH_CHATBOT_VERSION=latest

--- a/config/env.frontend.template
+++ b/config/env.frontend.template
@@ -1,2 +1,3 @@
 ## frontend env
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_CHATBOT_URL=http://localhost:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,26 @@ services:
       - backend
     restart: unless-stopped
 
+  chatbot:
+    image: tokamaknetwork/tokamak-architect-bot:${TRH_CHATBOT_VERSION:-latest}
+    container_name: tokamak-architect-bot
+    ports:
+      - "8001:8001"
+    env_file:
+      - ./config/.env.chatbot
+    volumes:
+      - chatbot_data:/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    depends_on:
+      - backend
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   backend_storage:
+  chatbot_data:

--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -51,6 +51,15 @@ resource "aws_security_group" "trh_platform_security_group" {
     description = "Backend port 8000"
   }
 
+  # Chatbot API port 8001
+  ingress {
+    from_port   = 8001
+    to_port     = 8001
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Tokamak Architect Bot API"
+  }
+
   # All outbound traffic
   egress {
     from_port   = 0
@@ -119,14 +128,21 @@ resource "aws_instance" "trh_platform_ec2" {
       "# Copy template files",
       "cp config/env.backend.template config/.env.backend",
       "cp config/env.frontend.template config/.env.frontend",
+      "cp config/env.chatbot.template config/.env.chatbot",
       "# Configure frontend with instance public IP",
       "sed -i 's|^NEXT_PUBLIC_API_BASE_URL=.*|NEXT_PUBLIC_API_BASE_URL=http://${self.public_ip}:8000|' config/.env.frontend",
+      "sed -i 's|^NEXT_PUBLIC_CHATBOT_URL=.*|NEXT_PUBLIC_CHATBOT_URL=http://${self.public_ip}:8001|' config/.env.frontend",
       "# Configure backend with provided values",
       "sed -i 's|^DEFAULT_ADMIN_EMAIL=.*|DEFAULT_ADMIN_EMAIL=${var.admin_email}|' config/.env.backend",
       "sed -i 's|^DEFAULT_ADMIN_PASSWORD=.*|DEFAULT_ADMIN_PASSWORD=${var.admin_password}|' config/.env.backend",
+      "# Configure chatbot",
+      "sed -i 's|^TOKAMAK_AI_API_KEY=.*|TOKAMAK_AI_API_KEY=${var.tokamak_ai_api_key}|' config/.env.chatbot",
+      "sed -i 's|^CORS_ORIGINS=.*|CORS_ORIGINS=http://${self.public_ip}:3000|' config/.env.chatbot",
       "echo 'Environment configuration completed!'",
       "echo 'Running make setup...'", 
       "make setup",
+      "echo 'Ingesting chatbot documentation...'",
+      "docker compose exec -T chatbot python -m scripts.ingest || echo 'Chatbot ingestion will be retried after services are fully up'",
       "echo 'TRH Platform setup completed successfully!'"
     ]
   }

--- a/ec2/variables.tf
+++ b/ec2/variables.tf
@@ -37,3 +37,10 @@ variable "admin_password" {
   type        = string
   default     = "admin"
 }
+
+variable "tokamak_ai_api_key" {
+  description = "API key for Tokamak AI Gateway (chatbot)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
- Added the chatbot as a 4th service in docker-compose.yml (postgres, backend, ui, chatbot).
- Added a chatbot env template (config/env.chatbot.template) and wired it into the Makefile so make config / make ec2-deploy can set it up.
- Updated Terraform: security group now allows port 8001 for the chatbot API, and the EC2 provisioner configures chatbot env (API key, CORS) and frontend chatbot URL when deploying.
- Frontend env template now includes NEXT_PUBLIC_CHATBOT_URL so the UI can talk to the chatbot in production.